### PR TITLE
Add rudimentary XPCSession support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,14 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: macOS-14
+    runs-on: macOS-26
     env:
-      DEVELOPER_DIR: /Applications/Xcode_15.4.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_26.0.app/Contents/Developer
     strategy:
       matrix:
         destination:
           - "platform=macOS"
-          - "platform=iOS Simulator,name=iPhone 14"
+          - "platform=iOS Simulator,name=iPhone 17"
     steps:
       - uses: actions/checkout@v4
       - name: Test platform ${{ matrix.destination }}

--- a/Sources/Extendable/ConnectableConfiguration.swift
+++ b/Sources/Extendable/ConnectableConfiguration.swift
@@ -6,14 +6,6 @@ public struct ConnectableConfiguration: AppExtensionConfiguration {
 
 	private var handler: @MainActor (NSXPCConnection) -> Bool
 
-	@available(macOS 15.0, iOS 26, *)
-	@MainActor @preconcurrency
-	public init(
-		onSessionRequest requestHandler: @escaping @Sendable (XPCListener.IncomingSessionRequest) -> XPCListener.IncomingSessionRequest.Decision
-	) {
-		preconditionFailure()
-	}
-
 	@MainActor @preconcurrency
 	public init(onConnection connectionHandler: @escaping @Sendable (NSXPCConnection) -> Bool) {
 		self.handler = connectionHandler

--- a/Sources/Extendable/ConnectableExtension.swift
+++ b/Sources/Extendable/ConnectableExtension.swift
@@ -6,7 +6,7 @@ import SwiftUI
 public struct ConnectingAppExtensionConfiguration: AppExtensionConfiguration {
 	let accepter: ConnectionAccepter
 
-	public init(_ handler: @escaping ConnectionHandler) {
+	public init(_ handler: @escaping ExtendableConnectionHandler) {
 		self.accepter = ConnectionAccepter(handler)
 	}
 
@@ -15,14 +15,24 @@ public struct ConnectingAppExtensionConfiguration: AppExtensionConfiguration {
 	}
 }
 
+
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-public protocol ConnectableExtension: AppExtension {
+public protocol AnyConnectableExtension: AppExtension {}
+
+
+@available(macOS 26.0, iOS 26.0, *)
+public protocol XPCConnectableExtension: AnyConnectableExtension {
+	var configuration: ConnectionHandler{get}
+}
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+public protocol ConnectableExtension: AnyConnectableExtension {
 	func acceptConnection(_ connection: NSXPCConnection) throws
 }
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public extension ConnectableExtension {
-	/// The global, per-exension configuration
+	/// The global, per-extension configuration
 	///
 	/// This configuration applies to the extension process, and
 	/// its connection corresponds to `AppExtensionProcess`. This
@@ -40,6 +50,6 @@ public extension ConnectableExtension {
 
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-public protocol NewConnectableExtension: AppExtension {
+public protocol NewConnectableExtension: ConnectableExtension {
 	func acceptConnection(_ connection: NSXPCConnection) throws
 }

--- a/Sources/Extendable/ConnectableSceneExtension.swift
+++ b/Sources/Extendable/ConnectableSceneExtension.swift
@@ -20,3 +20,21 @@ public extension ConnectableSceneExtension {
 		return AppExtensionSceneConfiguration(scene, configuration: globalConfiguration)
 	}
 }
+
+
+/// Defines an interface between a host and view-based extension.
+///
+/// This type provides more structure to a view-based extension.
+@available(macOS 26.0, iOS 26.0, *)
+public protocol XPCConnectableSceneExtension<Content>: XPCConnectableExtension {
+	associatedtype Content : AppExtensionScene
+
+	var scene: Content { get }
+}
+
+@available(macOS 26.0, iOS 26.0, *)
+public extension XPCConnectableSceneExtension {
+	var configuration: AppExtensionSceneConfiguration {
+		return AppExtensionSceneConfiguration(scene, configuration: configuration)
+	}
+}

--- a/Sources/Extendable/ConnectionAccepter.swift
+++ b/Sources/Extendable/ConnectionAccepter.swift
@@ -1,14 +1,14 @@
 import Foundation
 import os.log
 
-public typealias ConnectionHandler = (NSXPCConnection) throws -> Void
+public typealias ExtendableConnectionHandler = (NSXPCConnection) throws -> Void
 
 struct ConnectionAccepter {
 	private let logger = Logger(subsystem: "com.chimehq.Extendable", category: "ConnectionAccepter")
 
-	let handler: ConnectionHandler
+	let handler: ExtendableConnectionHandler
 
-	init(_ handler: @escaping ConnectionHandler) {
+	init(_ handler: @escaping ExtendableConnectionHandler) {
 		self.handler = handler
 	}
 


### PR DESCRIPTION
This pull request adds basic XPCSession support for the parts of the library reliant on ExtensionFoundation. However, I found out the hard way that ExtensionKit still doesn't support XPCSession, so most of the library is untouched.

All of the new XPCSession support is prefixed with "XPC" as to not break backwards-compatibility.

Related to #2 